### PR TITLE
RRMS-39-add-implementation-of-mock-data-for-parse-api-service

### DIFF
--- a/frontend/src/app/content/current-page/current-page.component.html
+++ b/frontend/src/app/content/current-page/current-page.component.html
@@ -4,18 +4,18 @@
   <section class="time">
       {{ time$ | async | date:'HH:mm:ss' }}
   </section>
-  <section class="sensors">
-      <div class="sensor">
-          <div class="sensor__value">26°C</div>
-          <img src="./assets/img/temperature.svg" alt="" class="sensor__image">
-      </div>
-      <div class="sensor">
-          <div class="sensor__value">26Pa</div>
-          <img src="./assets/img/pressure.svg" alt="" class="sensor__image">
-      </div>
-      <div class="sensor">
-          <div class="sensor__value">26%</div>
-          <img src="./assets/img/humidity.svg" alt="" class="sensor__image">
-      </div>
-  </section>
+  <section class="sensors" *ngIf="currentValues$ | async as currentValues">
+    <div class="sensor">
+        <div class="sensor__value"><div>{{currentValues.temperature}}°C</div></div>
+        <img src="./assets/img/temperature.svg" alt="" class="sensor__image">
+    </div>
+    <div class="sensor">
+        <div class="sensor__value sensor__value--pascal"><div>{{currentValues.pressure}}kPa</div></div>
+        <img src="./assets/img/pressure.svg" alt="" class="sensor__image">
+    </div>
+    <div class="sensor">
+        <div class="sensor__value"><div>{{currentValues.humidity}}%</div></div>
+        <img src="./assets/img/humidity.svg" alt="" class="sensor__image">
+    </div>
+</section>
 </main>

--- a/frontend/src/app/content/current-page/current-page.component.ts
+++ b/frontend/src/app/content/current-page/current-page.component.ts
@@ -1,5 +1,7 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { Observable, map, timer } from 'rxjs';
+import { Observable, map, timer, switchMap } from 'rxjs';
+import { ICurrentValues } from 'src/app/shared/interfaces';
+import { ParseApiService } from 'src/app/shared/services/parse-api.service';
 
 @Component({
   selector: 'app-current-page',
@@ -10,12 +12,18 @@ import { Observable, map, timer } from 'rxjs';
 export class CurrentPageComponent implements OnInit {
 
   public time$!: Observable<Date>;
+  public currentValues$!: Observable<ICurrentValues>;
 
-  constructor() { }
+  constructor(
+    private parseApiService: ParseApiService
+  ) { }
 
   ngOnInit(): void {
     this.time$ = timer(0, 1000).pipe(
       map(() => new Date()));
+
+    this.currentValues$ = timer(0, 1000).pipe(
+      switchMap(() => this.parseApiService.getCurrent()));
   }
 
 }

--- a/frontend/src/app/shared/services/parse-api.service.ts
+++ b/frontend/src/app/shared/services/parse-api.service.ts
@@ -1,7 +1,10 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { ICurrentValues, ILastValues } from '../interfaces';
+import { Observable, of } from 'rxjs';
+import { IChartValue, ICurrentValues, ILastValues } from '../interfaces';
+
+const IS_MOCK: boolean = false;
+const API_PATH: string = '/api';
 
 @Injectable({
   providedIn: 'root'
@@ -11,13 +14,37 @@ export class ParseApiService {
   constructor(
     private http: HttpClient
   ) { }
+  
+  mockLastValues: IChartValue[] = [];
+
+  getMockLastValues(amount: number): Observable<ILastValues> {
+    const value = 24 + (Math.random() - 0.5) * 5;
+    this.mockLastValues.push({ value: [new Date, value] });
+    const mockData = this.mockLastValues.slice(-amount);
+    return of({
+      temperature: mockData,
+      pressure: mockData,
+      humidity: mockData
+    });
+  }
+
+  getMockCurrent(): Observable<ICurrentValues> {
+    const value = Math.round(24 + (Math.random() - 0.5) * 5);
+    return of({
+      temperature: value,
+      pressure: value,
+      humidity: value
+    });
+  }
 
   getCurrent(): Observable<ICurrentValues> {
-    return this.http.get<ICurrentValues>('/api/current');
+    if (IS_MOCK) return this.getMockCurrent();
+    return this.http.get<ICurrentValues>(API_PATH + '/current');
   }
 
   getLastValues(amount: number): Observable<ILastValues> {
-    return this.http.get<ILastValues>('/api/last-values', {
+    if (IS_MOCK) return this.getMockLastValues(amount);
+    return this.http.get<ILastValues>(API_PATH + '/last-values', {
       headers: { amount: String(amount) }
     });
   }


### PR DESCRIPTION
Add implementation of mock data for parse api service.

![image](https://user-images.githubusercontent.com/82032813/215316159-9301423f-c0c0-4c6f-8f18-9eb2c5fe8f23.png)

